### PR TITLE
Refactoring and code reorganization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,12 +216,14 @@ export default function App() {
         dataSources: dataSources
     }), [dataSources]);
 
+    // Set the marker ID and description for the UAV point marker
     useEffect(() => {
-        // Set the marker ID and description for the UAV point marker
         uavPointMarker.props.markerId = "UAV UAS";
         uavPointMarker.props.description = "UAV UAS";
+    }, [uavPointMarker])
 
-        // Create the video view with the UAV video data layer
+    // Create the video view with the UAV video data layer
+    useEffect(() => {
         const videoView = new VideoView({
             container: "video-window",
             css: 'video-h264',
@@ -231,8 +233,10 @@ export default function App() {
             showStats: false,
             layers: [videoDataLayer]
         });
+    }, [])
 
-        // Create the Cesium view with the UAV point marker and bounded draping layers
+    // Create the Cesium view with the UAV point marker and bounded draping layers
+    useEffect(() => {
         const cesiumView = new CesiumView({
             container: "cesium-container",
             layers: [uavPointMarker, boundedDrapingLayer],
@@ -272,8 +276,9 @@ export default function App() {
         cesiumView.viewer.camera.flyTo({
             destination: Cartesian3.fromDegrees(-86.67128902952935, 34.70690480206765, 10000)
         });
+    }, [])
 
-        // Start streaming
+    // Start streaming
         masterTimeController.connect();
     }, [])
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,9 @@ export default function App() {
     const videoDsId = "h225hesual08g";
     const fovDsId = "iabpf1ivua1qm";
 
+    const cesiumContainer = useRef(null);
+    const videoContainer = useRef(null);
+
     //#region Data Sources
     /**
      * UAV Location data source
@@ -225,7 +228,7 @@ export default function App() {
     // Create the video view with the UAV video data layer
     useEffect(() => {
         const videoView = new VideoView({
-            container: "video-window",
+            container: videoContainer.current.id,
             css: 'video-h264',
             name: "UAV Video",
             framerate: 25,
@@ -238,7 +241,7 @@ export default function App() {
     // Create the Cesium view with the UAV point marker and bounded draping layers
     useEffect(() => {
         const cesiumView = new CesiumView({
-            container: "cesium-container",
+            container: cesiumContainer.current.id,
             layers: [uavPointMarker, boundedDrapingLayer],
             options: {
                 viewerProps: {
@@ -279,17 +282,18 @@ export default function App() {
     }, [])
 
     // Start streaming
+    useEffect(() => {
         masterTimeController.connect();
     }, [])
 
     return (
         <div id="container">
             <div id="left">
-                <div id="cesium-container"></div>
+                <div id="cesium-container" ref={cesiumContainer}></div>
             </div>
             <div id="right">
                 <div className="title">UAV Video Stream</div>
-                <div id="video-window"></div>
+                <div id="video-window" ref={videoContainer}></div>
             </div>
         </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,31 +12,17 @@
  * source code for files added in the larger work.
  *
  */
-import React, { useEffect, useMemo, useRef } from "react";
 
-// @ts-ignore
-import {
-    Cartesian3,
-    Ion,
-    SceneMode,
-    Terrain,
-} from "@cesium/engine";
+import React, { useEffect, useMemo, useRef } from "react";
+import { Cartesian3, Ion, SceneMode, Terrain, } from "@cesium/engine";
 import "@cesium/engine/Source/Widget/CesiumWidget.css";
-// @ts-ignore
 import CesiumView from "osh-js/source/core/ui/view/map/CesiumView.js";
-// @ts-ignore
 import DataSynchronizer from 'osh-js/source/core/timesync/DataSynchronizer';
-// @ts-ignore
 import { Mode } from "osh-js/source/core/datasource/Mode";
-// @ts-ignore
 import PointMarkerLayer from "osh-js/source/core/ui/layer/PointMarkerLayer";
-// @ts-ignore
 import PolygonLayer from "osh-js/source/core/ui/layer/PolygonLayer";
-// @ts-ignore
 import SweApi from "osh-js/source/core/datasource/sweapi/SweApi.datasource";
-// @ts-ignore
 import VideoDataLayer from "osh-js/source/core/ui/layer/VideoDataLayer";
-// @ts-ignore
 import VideoView from "osh-js/source/core/ui/view/video/VideoView";
 
 export default function App() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,16 +13,11 @@
  *
  */
 
-// @ts-ignore
 import React from 'react'
-// @ts-ignore
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import {Provider} from 'react-redux'
 
 // As of React 18
 const root = ReactDOM.createRoot(document.getElementById('root'))
 
-root.render(
-        <App/>
-)
+root.render(<App />)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "lib": ["dom", "es2015"],
+    "lib": [
+      "dom",
+      "es2015"
+    ],
     "module": "commonjs",
     "noImplicitAny": true,
     "outDir": "./build/",
@@ -9,5 +12,8 @@
     "target": "es5",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["./src/**/*"]
+  "include": [
+    "./src/**/*",
+    "./types/osh-js.d.tsx"
+  ]
 }

--- a/types/osh-js.d.tsx
+++ b/types/osh-js.d.tsx
@@ -1,0 +1,1 @@
+declare module "osh-js/source/core/*"


### PR DESCRIPTION
List of changes:
* Moved declaration of fields, data sources, layers, and the time controller outside of useEffect. useMemo is used so that data sources, layers, and the time controller are still only created once. Since they are now outside of useEffect, they can be accessed and modified by events, if needed.
* Separated the monolithic effect into several smaller, contextually related effects for code clarity.
* Used useRef on the video and cesium container divs so that their IDs can be accessed programmatically rather than by duplicating a string.
* Resolved the 'Could not find a declaration file for module x' error by adding an osh-js.d.tsx file which declares "osh-js/source/core/*" as a module. Now any imports using this code will not show as an error. Also removed the associated ts-ignore for these import lines.
* Reorganized code so that data sources and layers are in their own regions.
* Added and expanded comments to make it more clear what each thing does and how it will be used.